### PR TITLE
Fix password not requested

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -3,7 +3,7 @@ import json
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import getpass
 
-from paramiko import SSHClient
+from paramiko import AutoAddPolicy, SSHClient
 from scp import SCPClient
 
 
@@ -13,8 +13,9 @@ RM_TEMPLATES_DIR = Path("/usr/share/remarkable/templates/")
 def main(args):
     ssh = SSHClient()
     ssh.load_system_host_keys()
+    ssh.set_missing_host_key_policy(AutoAddPolicy())
 
-    password = getpass.getpass() if args.password else None
+    password = args.password or getpass.getpass("reMarkable password: ")
     ssh.connect(args.host, username=args.user, password=password)
 
     scp = SCPClient(ssh.get_transport())


### PR DESCRIPTION
When no remarkable password is specified to upload.py, `getpass()` is supposed to request the password via a prompt. However the condition was set to request a password if it is already specified. Probably the intention was to request a password via a prompt if no password was provided via command line arguments.